### PR TITLE
Update copyright year to 2026

### DIFF
--- a/src/BlazingSingularity/BlazingSingularity.csproj
+++ b/src/BlazingSingularity/BlazingSingularity.csproj
@@ -13,7 +13,7 @@
     <PackageTags>blazor;command;relay-command;mvvm;source-generator;icommand;async-command</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Copyright>Copyright (c) 2025 Lorefist</Copyright>
+    <Copyright>Copyright (c) 2026 Lorefist</Copyright>
     <!-- Include debug symbols in package -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026 in `BlazingSingularity.csproj`

Closes #9