### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BlazingSingularity
 
+[![Build](https://github.com/andres-m-rodriguez/BlazingSingularity/actions/workflows/build.yml/badge.svg)](https://github.com/andres-m-rodriguez/BlazingSingularity/actions/workflows/build.yml)
+
 WPF-style `[RelayCommand]` for Blazor, powered by source generators.
 
 ## Installation


### PR DESCRIPTION
## Summary
- Add GitHub Actions build workflow badge to the top of the README

Closes #8