### PR TITLE
Remove multi-parameter ValueTuple support

### DIFF
--- a/src/BlazingSingularity.SourceGenerators/DiagnosticDescriptors.cs
+++ b/src/BlazingSingularity.SourceGenerators/DiagnosticDescriptors.cs
@@ -20,7 +20,7 @@ public static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor BLAZING002 = new(
         id: "BLAZING002",
         title: "Too many RelayCommand parameters",
-        messageFormat: "Method '{0}' has {1} parameters. [RelayCommand] supports up to 8 parameters. Consider creating a parameter class.",
+        messageFormat: "Method '{0}' has {1} parameters. [RelayCommand] supports up to 1 parameter. Consider creating a DTO.",
         category: "BlazingSingularity.Commands",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true

--- a/src/BlazingSingularity.SourceGenerators/RelayCommandGenerator.cs
+++ b/src/BlazingSingularity.SourceGenerators/RelayCommandGenerator.cs
@@ -110,14 +110,14 @@ public class RelayCommandGenerator : IIncrementalGenerator
                 continue;
             }
 
-            // Report BLAZING002 for methods with >8 parameters
+            // Report BLAZING002 for methods with >1 parameter
             foreach (var method in group)
             {
                 var methodSymbol = semanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
                 if (methodSymbol != null)
                 {
                     var paramInfo = RelayCommandHelpers.GetCommandParameters(methodSymbol);
-                    if (paramInfo.CommandParameters.Length > 8)
+                    if (paramInfo.CommandParameters.Length > 1)
                     {
                         context.ReportDiagnostic(
                             Diagnostic.Create(

--- a/src/BlazingSingularity.SourceGenerators/SourceGeneratorHelpers/RelayCommandHelpers.cs
+++ b/src/BlazingSingularity.SourceGenerators/SourceGeneratorHelpers/RelayCommandHelpers.cs
@@ -126,47 +126,9 @@ public static class RelayCommandHelpers
                         : wrapper;
             }
         }
-        else if (commandParameters.Length >= 2 && commandParameters.Length <= 8)
-        {
-            // Multiple parameters (2-8) - use ValueTuple
-            var tupleTypes = string.Join(
-                ", ",
-                commandParameters.Select(p => p.Type.ToDisplayString())
-            );
-            var tupleType = $"({tupleTypes})";
-
-            commandType = $"AsyncRelayCommand<{tupleType}>";
-
-            // Generate lambda wrapper to unwrap tuple
-            var tupleItems = string.Join(
-                ", ",
-                Enumerable.Range(1, commandParameters.Length).Select(i => $"param.Item{i}")
-            );
-
-            string lambdaWrapper;
-            if (isAsync)
-            {
-                lambdaWrapper = $"param => {methodName}({tupleItems})";
-            }
-            else
-            {
-                lambdaWrapper = $"param => {{ {methodName}({tupleItems}); return System.Threading.Tasks.Task.CompletedTask; }}";
-            }
-
-            // Handle CanExecute
-            if (canExecuteMethod != null)
-            {
-                var canExecuteLambda = $"param => {canExecuteMethodName}({tupleItems})";
-                constructorArgs = $"{lambdaWrapper}, {canExecuteLambda}";
-            }
-            else
-            {
-                constructorArgs = lambdaWrapper;
-            }
-        }
         else
         {
-            // More than 8 parameters not supported
+            // More than 1 parameter not supported
             return null;
         }
 

--- a/tests/BlazingSingularity.SourceGenerators.Tests/RelayCommandGeneratorTests.cs
+++ b/tests/BlazingSingularity.SourceGenerators.Tests/RelayCommandGeneratorTests.cs
@@ -187,7 +187,7 @@ public class RelayCommandGeneratorTests
     }
 
     [Fact]
-    public void MethodWithMoreThan8Parameters_ReportsBLAZING002()
+    public void MethodWithMoreThan1Parameter_ReportsBLAZING002()
     {
         var source = """
             using System.Threading.Tasks;
@@ -198,9 +198,7 @@ public class RelayCommandGeneratorTests
             public partial class MyViewModel
             {
                 [RelayCommand]
-                public async Task DoSomethingAsync(
-                    int p1, int p2, int p3, int p4,
-                    int p5, int p6, int p7, int p8, int p9)
+                public async Task DoSomethingAsync(int p1, int p2)
                 {
                     await Task.CompletedTask;
                 }
@@ -216,7 +214,7 @@ public class RelayCommandGeneratorTests
     }
 
     [Fact]
-    public void MultipleParameters_ProducesValueTupleCommand()
+    public void MultipleParameters_ReportsBLAZING002()
     {
         var source = """
             using System.Threading.Tasks;
@@ -236,14 +234,10 @@ public class RelayCommandGeneratorTests
 
         var result = GeneratorTestHelper.RunRelayCommandGenerator(source);
 
-        Assert.Empty(result.Diagnostics);
-        var generated = Assert.Single(result.GeneratedTrees);
-        var generatedSource = generated.GetText().ToString();
-
-        Assert.Contains("AsyncRelayCommand<(string, int)>", generatedSource);
-        Assert.Contains("UpdateAsyncCommand", generatedSource);
-        Assert.Contains("param.Item1", generatedSource);
-        Assert.Contains("param.Item2", generatedSource);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("BLAZING002", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("UpdateAsync", diagnostic.GetMessage());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Removed the 2-8 parameter ValueTuple branch from `RelayCommandHelpers.GetCommandTypeInfo()`, so `[RelayCommand]` now supports 0 or 1 parameter only
- Updated BLAZING002 diagnostic to reflect the new 1-parameter limit and suggest a DTO
- Changed the parameter count threshold in `RelayCommandGenerator` from `> 8` to `> 1`
- Updated tests to expect BLAZING002 for multi-parameter methods instead of generated ValueTuple code

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [x] `dotnet test` passes all 25 tests

Closes #7