### PR TITLE
Add IFetch<T> and IBackgroundFetch<T> for reactive async data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,66 @@ Use the generated property in your Razor markup:
 ```razor
 <input @bind="SearchText" @bind:event="oninput" />
 ```
+
+### Async Data Fetching with `Fetch<T>`
+
+Use `Fetch<T>` for reactive async data loading with built-in loading/error/success states:
+
+```csharp
+using BlazingSingularity.Fetch;
+
+public partial class TodosPage : ComponentBase, IDisposable
+{
+    [Inject] private HttpClient Http { get; set; } = null!;
+
+    private Fetch<List<Todo>> TodosFetch = null!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        TodosFetch = new Fetch<List<Todo>>(
+            ct => Http.GetFromJsonAsync<List<Todo>>("/api/todos", ct)!,
+            () => InvokeAsync(StateHasChanged)
+        );
+        await TodosFetch.FetchAsync();
+    }
+
+    public void Dispose() => TodosFetch.Dispose();
+}
+```
+
+```razor
+@if (TodosFetch.IsLoading) { <Spinner /> }
+else if (TodosFetch.IsError) { <p>Error: @TodosFetch.Error?.Message</p> }
+else if (TodosFetch.HasData)
+{
+    @foreach (var todo in TodosFetch.Data!)
+    {
+        <p>@todo.Title</p>
+    }
+}
+```
+
+### Stale-While-Revalidate with `BackgroundFetch<T>`
+
+Use `BackgroundFetch<T>` to show cached data instantly while refreshing in the background:
+
+```csharp
+private BackgroundFetch<OrgDto> OrgFetch = null!;
+
+protected override async Task OnInitializedAsync()
+{
+    OrgFetch = new BackgroundFetch<OrgDto>(
+        ct => Http.GetFromJsonAsync<OrgDto>($"/api/orgs/{OrgId}", ct)!,
+        () => InvokeAsync(StateHasChanged)
+    );
+    OrgFetch.SetInitialData(CachedOrg);  // Display immediately
+    await OrgFetch.FetchAsync();          // Refresh in background
+}
+```
+
+```razor
+<div class="@(OrgFetch.IsStale ? "opacity-50" : "")">
+    @if (OrgFetch.IsRefreshing) { <SmallSpinner /> }
+    <h1>@OrgFetch.Data?.Name</h1>
+</div>
+```

--- a/src/BlazingSingularity/Fetch/BackgroundFetch.cs
+++ b/src/BlazingSingularity/Fetch/BackgroundFetch.cs
@@ -1,0 +1,153 @@
+namespace BlazingSingularity.Fetch;
+
+public class BackgroundFetch<T> : IBackgroundFetch<T>, IDisposable
+{
+    private readonly Func<CancellationToken, Task<T>> _fetchFunc;
+    private readonly Func<Task>? _notifyStateChanged;
+    private readonly List<Action<IFetch<T>>> _callbacks = [];
+    private CancellationTokenSource? _cancellationTokenSource;
+    private bool _disposed;
+
+    private FetchStatus _status = FetchStatus.Idle;
+    private T? _freshData;
+    private T? _staleData;
+    private Exception? _error;
+    private DateTime? _lastFetchedAt;
+
+    public BackgroundFetch(Func<CancellationToken, Task<T>> fetchFunc, Func<Task>? notifyStateChanged = null)
+    {
+        _fetchFunc = fetchFunc ?? throw new ArgumentNullException(nameof(fetchFunc));
+        _notifyStateChanged = notifyStateChanged;
+    }
+
+    public FetchStatus Status => _status;
+    public T? Data => _freshData ?? _staleData;
+    public T? StaleData => _staleData;
+    public Exception? Error => _error;
+    public DateTime? LastFetchedAt => _lastFetchedAt;
+    public TimeSpan? StaleTime { get; set; }
+
+    public bool IsIdle => _status == FetchStatus.Idle;
+    public bool IsLoading => _status == FetchStatus.Loading;
+    public bool IsSuccess => _status == FetchStatus.Success;
+    public bool IsError => _status == FetchStatus.Error;
+    public bool HasData => Data is not null;
+
+    public bool IsStale
+    {
+        get
+        {
+            if (_freshData is null && _staleData is not null)
+                return true;
+
+            if (StaleTime.HasValue && _lastFetchedAt.HasValue)
+                return DateTime.UtcNow - _lastFetchedAt.Value > StaleTime.Value;
+
+            return false;
+        }
+    }
+
+    public bool IsRefreshing => IsLoading && _staleData is not null;
+
+    public void SetInitialData(T? data)
+    {
+        _staleData = data;
+    }
+
+    public async Task FetchAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        await SetStatusAsync(FetchStatus.Loading);
+
+        try
+        {
+            var result = await _fetchFunc(_cancellationTokenSource.Token);
+
+            if (_cancellationTokenSource.Token.IsCancellationRequested)
+                return;
+
+            if (!EqualityComparer<T>.Default.Equals(_freshData, result))
+            {
+                _freshData = result;
+            }
+
+            _error = null;
+            _lastFetchedAt = DateTime.UtcNow;
+            await SetStatusAsync(FetchStatus.Success);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelled - don't update status
+        }
+        catch (Exception ex)
+        {
+            _error = ex;
+            // Keep stale data available on error
+            await SetStatusAsync(FetchStatus.Error);
+        }
+    }
+
+    public async Task RefetchAsync(CancellationToken ct = default)
+    {
+        // Move fresh data to stale before refetching
+        if (_freshData is not null)
+        {
+            _staleData = _freshData;
+            _freshData = default;
+        }
+
+        await FetchAsync(ct);
+    }
+
+    public void Reset()
+    {
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+
+        _status = FetchStatus.Idle;
+        _freshData = default;
+        _staleData = default;
+        _error = null;
+        _lastFetchedAt = null;
+
+        NotifyCallbacks();
+    }
+
+    public void OnChange(Action callback) => _callbacks.Add(_ => callback());
+
+    public void OnChange(Action<IFetch<T>> callback) => _callbacks.Add(callback);
+
+    private async Task SetStatusAsync(FetchStatus status)
+    {
+        _status = status;
+        NotifyCallbacks();
+
+        if (_notifyStateChanged != null)
+        {
+            await _notifyStateChanged();
+        }
+    }
+
+    private void NotifyCallbacks()
+    {
+        foreach (var callback in _callbacks)
+            callback(this);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+        _callbacks.Clear();
+    }
+}

--- a/src/BlazingSingularity/Fetch/Fetch.cs
+++ b/src/BlazingSingularity/Fetch/Fetch.cs
@@ -1,0 +1,116 @@
+namespace BlazingSingularity.Fetch;
+
+public class Fetch<T> : IFetch<T>, IDisposable
+{
+    private readonly Func<CancellationToken, Task<T>> _fetchFunc;
+    private readonly Func<Task>? _notifyStateChanged;
+    private readonly List<Action<IFetch<T>>> _callbacks = [];
+    private CancellationTokenSource? _cancellationTokenSource;
+    private bool _disposed;
+
+    private FetchStatus _status = FetchStatus.Idle;
+    private T? _data;
+    private Exception? _error;
+
+    public Fetch(Func<CancellationToken, Task<T>> fetchFunc, Func<Task>? notifyStateChanged = null)
+    {
+        _fetchFunc = fetchFunc ?? throw new ArgumentNullException(nameof(fetchFunc));
+        _notifyStateChanged = notifyStateChanged;
+    }
+
+    public FetchStatus Status => _status;
+    public T? Data => _data;
+    public Exception? Error => _error;
+
+    public bool IsIdle => _status == FetchStatus.Idle;
+    public bool IsLoading => _status == FetchStatus.Loading;
+    public bool IsSuccess => _status == FetchStatus.Success;
+    public bool IsError => _status == FetchStatus.Error;
+    public bool HasData => _data is not null;
+
+    public async Task FetchAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        await SetStatusAsync(FetchStatus.Loading);
+
+        try
+        {
+            var result = await _fetchFunc(_cancellationTokenSource.Token);
+
+            if (_cancellationTokenSource.Token.IsCancellationRequested)
+                return;
+
+            if (!EqualityComparer<T>.Default.Equals(_data, result))
+            {
+                _data = result;
+            }
+
+            _error = null;
+            await SetStatusAsync(FetchStatus.Success);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelled - don't update status
+        }
+        catch (Exception ex)
+        {
+            _error = ex;
+            await SetStatusAsync(FetchStatus.Error);
+        }
+    }
+
+    public async Task RefetchAsync(CancellationToken ct = default)
+    {
+        await FetchAsync(ct);
+    }
+
+    public void Reset()
+    {
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+
+        _status = FetchStatus.Idle;
+        _data = default;
+        _error = null;
+
+        NotifyCallbacks();
+    }
+
+    public void OnChange(Action callback) => _callbacks.Add(_ => callback());
+
+    public void OnChange(Action<IFetch<T>> callback) => _callbacks.Add(callback);
+
+    private async Task SetStatusAsync(FetchStatus status)
+    {
+        _status = status;
+        NotifyCallbacks();
+
+        if (_notifyStateChanged != null)
+        {
+            await _notifyStateChanged();
+        }
+    }
+
+    private void NotifyCallbacks()
+    {
+        foreach (var callback in _callbacks)
+            callback(this);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _cancellationTokenSource?.Cancel();
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+        _callbacks.Clear();
+    }
+}

--- a/src/BlazingSingularity/Fetch/FetchStatus.cs
+++ b/src/BlazingSingularity/Fetch/FetchStatus.cs
@@ -1,0 +1,9 @@
+namespace BlazingSingularity.Fetch;
+
+public enum FetchStatus
+{
+    Idle,
+    Loading,
+    Success,
+    Error
+}

--- a/src/BlazingSingularity/Fetch/IBackgroundFetch.cs
+++ b/src/BlazingSingularity/Fetch/IBackgroundFetch.cs
@@ -1,0 +1,12 @@
+namespace BlazingSingularity.Fetch;
+
+public interface IBackgroundFetch<T> : IFetch<T>
+{
+    bool IsStale { get; }
+    bool IsRefreshing { get; }
+    DateTime? LastFetchedAt { get; }
+    T? StaleData { get; }
+
+    void SetInitialData(T? data);
+    TimeSpan? StaleTime { get; set; }
+}

--- a/src/BlazingSingularity/Fetch/IFetch.cs
+++ b/src/BlazingSingularity/Fetch/IFetch.cs
@@ -1,0 +1,21 @@
+namespace BlazingSingularity.Fetch;
+
+public interface IFetch<T>
+{
+    FetchStatus Status { get; }
+    T? Data { get; }
+    Exception? Error { get; }
+
+    bool IsIdle { get; }
+    bool IsLoading { get; }
+    bool IsSuccess { get; }
+    bool IsError { get; }
+    bool HasData { get; }
+
+    Task FetchAsync(CancellationToken ct = default);
+    Task RefetchAsync(CancellationToken ct = default);
+    void Reset();
+
+    void OnChange(Action callback);
+    void OnChange(Action<IFetch<T>> callback);
+}

--- a/src/demo/BlazingSingularity.Demo.Client/FetchDemo/Pages/FetchDemo.razor
+++ b/src/demo/BlazingSingularity.Demo.Client/FetchDemo/Pages/FetchDemo.razor
@@ -1,0 +1,211 @@
+@page "/fetch-demo"
+@using BlazingSingularity.Demo.Client.Todo.HttpClients
+@using BlazingSingularity.Demo.Client.Todo.Dtos
+@using BlazingSingularity.Fetch
+@inject TodoHttpClient TodoHttpClient
+
+@rendermode @(new InteractiveWebAssemblyRenderMode(false))
+
+<h3>Fetch Demo</h3>
+
+<div class="row">
+    @* Basic Fetch<T> Demo *@
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>Basic Fetch&lt;T&gt;</h5>
+                <small class="text-muted">Simple async data fetching with loading/error states</small>
+            </div>
+            <div class="card-body">
+                <div class="mb-2">
+                    <button class="btn btn-primary btn-sm me-2" @onclick="() => BasicFetch.FetchAsync()">
+                        Fetch
+                    </button>
+                    <button class="btn btn-secondary btn-sm me-2" @onclick="() => BasicFetch.RefetchAsync()">
+                        Refetch
+                    </button>
+                    <button class="btn btn-outline-secondary btn-sm" @onclick="() => BasicFetch.Reset()">
+                        Reset
+                    </button>
+                </div>
+
+                <div class="mb-2">
+                    <span class="badge @GetStatusBadgeClass(BasicFetch.Status)">@BasicFetch.Status</span>
+                    @if (BasicFetch.HasData)
+                    {
+                        <span class="badge bg-info ms-1">HasData</span>
+                    }
+                </div>
+
+                @if (BasicFetch.IsLoading)
+                {
+                    <div class="d-flex justify-content-center my-3">
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                }
+                else if (BasicFetch.IsError)
+                {
+                    <div class="alert alert-danger" role="alert">
+                        @BasicFetch.Error?.Message
+                    </div>
+                }
+                else if (BasicFetch.HasData)
+                {
+                    <ul class="list-group list-group-flush">
+                        @foreach (var todo in BasicFetch.Data!.Take(5))
+                        {
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                @todo.Title
+                                @if (todo.IsCompleted)
+                                {
+                                    <span class="badge bg-success">Done</span>
+                                }
+                            </li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <p class="text-muted">Click "Fetch" to load data</p>
+                }
+            </div>
+        </div>
+    </div>
+
+    @* BackgroundFetch<T> Demo *@
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>BackgroundFetch&lt;T&gt;</h5>
+                <small class="text-muted">Stale-while-revalidate pattern with instant display</small>
+            </div>
+            <div class="card-body">
+                <div class="mb-2">
+                    <button class="btn btn-primary btn-sm me-2" @onclick="() => BgFetch.FetchAsync()">
+                        Fetch
+                    </button>
+                    <button class="btn btn-secondary btn-sm me-2" @onclick="() => BgFetch.RefetchAsync()">
+                        Refetch
+                    </button>
+                    <button class="btn btn-outline-secondary btn-sm" @onclick="() => BgFetch.Reset()">
+                        Reset
+                    </button>
+                </div>
+
+                <div class="mb-2">
+                    <span class="badge @GetStatusBadgeClass(BgFetch.Status)">@BgFetch.Status</span>
+                    @if (BgFetch.IsStale)
+                    {
+                        <span class="badge bg-warning ms-1">Stale</span>
+                    }
+                    @if (BgFetch.IsRefreshing)
+                    {
+                        <span class="badge bg-info ms-1">Refreshing...</span>
+                    }
+                    @if (BgFetch.HasData)
+                    {
+                        <span class="badge bg-info ms-1">HasData</span>
+                    }
+                </div>
+
+                @if (BgFetch.LastFetchedAt.HasValue)
+                {
+                    <small class="text-muted d-block mb-2">
+                        Last fetched: @BgFetch.LastFetchedAt.Value.ToLocalTime().ToString("HH:mm:ss")
+                    </small>
+                }
+
+                @if (BgFetch.IsLoading && !BgFetch.HasData)
+                {
+                    <div class="d-flex justify-content-center my-3">
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                }
+                else if (BgFetch.IsError && !BgFetch.HasData)
+                {
+                    <div class="alert alert-danger" role="alert">
+                        @BgFetch.Error?.Message
+                    </div>
+                }
+                else if (BgFetch.HasData)
+                {
+                    <div class="position-relative">
+                        @if (BgFetch.IsRefreshing)
+                        {
+                            <div class="position-absolute top-0 end-0">
+                                <div class="spinner-border spinner-border-sm text-primary" role="status">
+                                    <span class="visually-hidden">Refreshing...</span>
+                                </div>
+                            </div>
+                        }
+                        <ul class="list-group list-group-flush @(BgFetch.IsStale ? "opacity-75" : "")">
+                            @foreach (var todo in BgFetch.Data!.Take(5))
+                            {
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    @todo.Title
+                                    @if (todo.IsCompleted)
+                                    {
+                                        <span class="badge bg-success">Done</span>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                }
+                else
+                {
+                    <p class="text-muted">Click "Fetch" to load data (initial data will display instantly)</p>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    private Fetch<List<TodoForListDto>> BasicFetch = null!;
+    private BackgroundFetch<List<TodoForListDto>> BgFetch = null!;
+
+    protected override void OnInitialized()
+    {
+        BasicFetch = new Fetch<List<TodoForListDto>>(
+            async ct =>
+            {
+                await Task.Delay(1000, ct); // Simulate network delay
+                return await TodoHttpClient.GetTodosAsync();
+            },
+            () => InvokeAsync(StateHasChanged)
+        );
+
+        BgFetch = new BackgroundFetch<List<TodoForListDto>>(
+            async ct =>
+            {
+                await Task.Delay(1500, ct); // Simulate slower network delay
+                return await TodoHttpClient.GetTodosAsync();
+            },
+            () => InvokeAsync(StateHasChanged)
+        );
+
+        // Set initial data to demonstrate stale-while-revalidate
+        BgFetch.SetInitialData([
+            new TodoForListDto(Guid.NewGuid(), "Initial cached item 1", false, DateTime.UtcNow),
+            new TodoForListDto(Guid.NewGuid(), "Initial cached item 2", true, DateTime.UtcNow),
+            new TodoForListDto(Guid.NewGuid(), "Initial cached item 3", false, DateTime.UtcNow)
+        ]);
+        BgFetch.StaleTime = TimeSpan.FromSeconds(30);
+
+        _ = BgFetch.FetchAsync();
+    }
+
+    private string GetStatusBadgeClass(FetchStatus status) => status switch
+    {
+        FetchStatus.Idle => "bg-secondary",
+        FetchStatus.Loading => "bg-primary",
+        FetchStatus.Success => "bg-success",
+        FetchStatus.Error => "bg-danger",
+        _ => "bg-secondary"
+    };
+}

--- a/src/demo/BlazingSingularity.Demo.Client/_Imports.razor
+++ b/src/demo/BlazingSingularity.Demo.Client/_Imports.razor
@@ -9,3 +9,4 @@
 @using BlazingSingularity.Demo.Client
 @using BlazingSingularity.Commands
 @using BlazingSingularity.Signals
+@using BlazingSingularity.Fetch

--- a/src/demo/BlazingSingularity.Demo.Server/Components/Layout/NavMenu.razor
+++ b/src/demo/BlazingSingularity.Demo.Server/Components/Layout/NavMenu.razor
@@ -31,6 +31,12 @@
                 <span class="bi bi-check2-square-nav-menu" aria-hidden="true"></span> Todos
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="fetch-demo">
+                <span class="bi bi-cloud-download-nav-menu" aria-hidden="true"></span> Fetch
+            </NavLink>
+        </div>
     </nav>
 </div>
 


### PR DESCRIPTION
## Summary

- Adds `IFetch<T>` and `Fetch<T>` for reactive async data fetching with loading/error/success states
- Adds `IBackgroundFetch<T>` and `BackgroundFetch<T>` for stale-while-revalidate pattern
- Both implement `IDisposable` for proper cleanup of `CancellationTokenSource`
- Includes demo page at `/fetch-demo` showing both patterns

## Test plan

- [ ] Build the solution: `dotnet build`
- [ ] Run unit tests: `dotnet test`
- [ ] Navigate to `/fetch-demo` and verify:
  - [ ] Basic Fetch shows loading spinner, then data
  - [ ] BackgroundFetch shows initial cached data immediately
  - [ ] BackgroundFetch shows refresh indicator while updating
  - [ ] Reset buttons clear state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)